### PR TITLE
Cleanup widgets directory, all as generic as possible

### DIFF
--- a/lib/company_widget.dart
+++ b/lib/company_widget.dart
@@ -10,6 +10,8 @@ import 'models/company.dart';
 import 'models/status.dart';
 import 'services/firestore.dart';
 import 'services/dates.dart';
+import 'services/utils.dart';
+import 'services/notifications.dart';
 
 class CompanyWidget extends StatelessWidget {
   final Company company;
@@ -18,13 +20,16 @@ class CompanyWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Status status = Status(company.closingDate, company.isOpen);
+
     return Scaffold(
       appBar: AppBar(
         flexibleSpace: GradientAppBar(title: company.name),
       ),
       body: Builder(
         builder: (BuildContext context) {
-          return SingleChildScrollView(padding: EdgeInsets.only(bottom: 20),
+          return SingleChildScrollView(
+            padding: EdgeInsets.only(bottom: 20),
             child: CurverCornerCard(
                 margin: EdgeInsets.all(15),
                 child: Column(
@@ -40,16 +45,24 @@ class CompanyWidget extends StatelessWidget {
                     _buildCompanyInfoRow(context, Icons.flight_takeoff,
                         company.founded, 'FOUNDED'),
                     Divider(),
-                    _buildCompanyInfoRow(context, Icons.calendar_today,
-                        formatDate(company.closingDate) ?? 'Unknown', 'CLOSING DATE', 'ADD'),
+                    _buildCompanyInfoRow(
+                        context,
+                        Icons.calendar_today,
+                        formatDate(company.closingDate) ?? 'Unknown',
+                        'CLOSING DATE',
+                        'ADD'),
                     Divider(),
                   ],
                 )),
           );
         },
       ),
-      bottomNavigationBar:
-          BottomAppBar(child: GradientBottomAppBar(company:company)),
+      bottomNavigationBar: BottomAppBar(
+          child: GradientBottomAppBar(
+              leftButtonPressed: () => launchURL(company.applyLink),
+              centerButtonPressed: () => shareURL(company.applyLink),
+              rightButtonPressed: () => arrangeNotification(context,
+                  company.name, 'Applications are ' + status.getName()))),
     );
   }
 
@@ -116,8 +129,7 @@ class CompanyWidget extends StatelessWidget {
 
   void _selectDate(BuildContext context) async {
     DateTime date = await datePicker(context);
-    if (date == null)
-      return;
+    if (date == null) return;
 
     saveClosingDate(company.name, date);
 
@@ -129,5 +141,4 @@ class CompanyWidget extends StatelessWidget {
           textAlign: TextAlign.center,
         )));
   }
-
 }

--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -7,10 +7,12 @@ FlutterLocalNotificationsPlugin notifyPlugin;
 Random random = new Random(DateTime.now().second);
 
 arrangeNotification(BuildContext context, String title, String body) async {
-  DateTime picked = await datePicker(context);
-  DateTime date = new DateTime(picked.year, picked.month, picked.day);
+  DateTime date = await datePicker(context);
+  if (date == null) return;
   TimeOfDay time = await timePicker(context);
+  if (time == null) return;
 
+  date = new DateTime(date.year, date.month, date.day);
   date = date.add(Duration(hours: time.hour, minutes: time.minute, seconds: 0));
   scheduleNotification(date, title, body);
 }

--- a/lib/submission.dart
+++ b/lib/submission.dart
@@ -122,7 +122,7 @@ class _SubmissionCardState extends State<SubmissionCard> {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: Colors.grey[300],
+      color: Colors.grey[200],
       margin: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
       shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.only(topLeft: Radius.circular(10.0))),

--- a/lib/widgets/gradient_bottom_app_bar.dart
+++ b/lib/widgets/gradient_bottom_app_bar.dart
@@ -1,71 +1,42 @@
 import 'package:flutter/material.dart';
 import 'gradient_box_decoration.dart';
-
-import '../services/utils.dart';
-import '../services/notifications.dart';
-import '../models/company.dart';
-import '../models/status.dart';
+import 'gradient_bottom_app_bar_button.dart';
 
 class GradientBottomAppBar extends StatelessWidget {
-  final Company company;
+  final Function leftButtonPressed;
+  final Function centerButtonPressed;
+  final Function rightButtonPressed;
 
-  GradientBottomAppBar({this.company});
+  GradientBottomAppBar(
+      {this.leftButtonPressed,
+      this.centerButtonPressed,
+      this.rightButtonPressed});
 
   @override
   Widget build(BuildContext context) {
-    Status status = Status(company.closingDate, company.isOpen);
-
     return Container(
       height: 70,
       decoration: GradientBoxDecoration.createGradient(context),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
-          _buildIconButton(context, Icons.near_me, 'Apply',
-              'Open application url', () => launchURL(company.applyLink)),
-          _buildIconButton(context, Icons.share, 'Share',
-              'Share application url', () => shareURL(company.applyLink)),
-          _buildIconButton(
-              context,
-              Icons.calendar_today,
-              'Notify',
-              'Notify before closing date',
-              () => arrangeNotification(context, company.name,
-                  'Applications are ' + status.getName()))
+          GradientBottomAppBarButton(
+              icon: Icons.near_me,
+              label: 'Apply',
+              tooltip: 'Open application url',
+              onPressed: leftButtonPressed),
+          GradientBottomAppBarButton(
+              icon: Icons.share,
+              label: 'Share',
+              tooltip: 'Share application url',
+              onPressed: centerButtonPressed),
+          GradientBottomAppBarButton(
+              icon: Icons.calendar_today,
+              label: 'Notify',
+              tooltip: 'Notify before closing date',
+              onPressed: rightButtonPressed),
         ],
       ),
-    );
-  }
-
-  Widget _buildIconButton(BuildContext context, IconData icon, String label,
-      String tooltip, Function onPressed) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Material(
-          color: Colors.transparent,
-          child: IconButton(
-            tooltip: tooltip,
-            highlightColor: Theme.of(context).accentColor,
-            padding: EdgeInsets.symmetric(horizontal: 25),
-            icon: Icon(
-              icon,
-              size: 30,
-            ),
-            onPressed: onPressed,
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 5.0),
-          child: Text(
-            label,
-            style: TextStyle(
-                fontSize: 14.0,
-                fontWeight: FontWeight.w500,
-                color: Colors.white),
-          ),
-        )
-      ],
     );
   }
 }

--- a/lib/widgets/gradient_bottom_app_bar_button.dart
+++ b/lib/widgets/gradient_bottom_app_bar_button.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class GradientBottomAppBarButton extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String tooltip;
+  final Function onPressed;
+
+  GradientBottomAppBarButton(
+      {this.icon, this.label, this.tooltip, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Material(
+          color: Colors.transparent,
+          child: IconButton(
+            tooltip: tooltip,
+            highlightColor: Theme.of(context).accentColor,
+            padding: EdgeInsets.symmetric(horizontal: 25),
+            icon: Icon(
+              icon,
+              size: 30,
+            ),
+            onPressed: onPressed,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 5.0),
+          child: Text(
+            label,
+            style: TextStyle(
+                fontSize: 14.0,
+                fontWeight: FontWeight.w500,
+                color: Colors.white),
+          ),
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Half-generic widgets in `/lib/widgets` had references to models + services hard-coded
- Pulled out `GradientBottomAppBarButton` into its own class
- Removed these dependencies so widgets take all required info as params only
- Fix ur merge conflict error and added the `arrangeNotification` bug fix back in